### PR TITLE
fix: Resolve ${ENV_VAR} references in gateway auth token

### DIFF
--- a/scripts/connect.sh
+++ b/scripts/connect.sh
@@ -89,6 +89,11 @@ start_connection() {
     
     echo "🚀 Starting WebSocket connection..."
     
+    # Source .env so the WS client can resolve ${VAR} references in gateway config
+    for envfile in "$HOME/.openclaw/.env" "$HOME/.clawdbot/.env"; do
+        [ -f "$envfile" ] && set -a && . "$envfile" && set +a
+    done
+    
     # Rotate log if it's too big (> 1MB)
     if [ -f "$LOG_FILE" ] && [ $(stat -f%z "$LOG_FILE" 2>/dev/null || stat -c%s "$LOG_FILE" 2>/dev/null || echo 0) -gt 1048576 ]; then
         echo "🔄 Rotating large log file..."

--- a/scripts/ws-client.js
+++ b/scripts/ws-client.js
@@ -47,6 +47,20 @@ VOICE RULES:
 - After using a tool, give a brief spoken confirmation of what you did.
 - NEVER output raw JSON, function calls, or code. Everything you say will be spoken aloud.`;
 
+/**
+ * Resolve ${ENV_VAR} references in a string value.
+ * Returns the original value if no match or env var not set.
+ */
+function resolveEnvVar(value) {
+  if (!value || typeof value !== 'string') return value;
+  var match = value.match(/^\$\{(.+)\}$/);
+  if (match) {
+    var envName = match[1];
+    return process.env[envName] || value;
+  }
+  return value;
+}
+
 function loadGatewayConfig() {
   for (var i = 0; i < CLAWDBOT_CONFIG_PATHS.length; i++) {
     try {
@@ -54,6 +68,10 @@ function loadGatewayConfig() {
         var config = JSON.parse(fs.readFileSync(CLAWDBOT_CONFIG_PATHS[i], 'utf8'));
         var port = (config.gateway && config.gateway.port) || 18789;
         var token = (config.gateway && config.gateway.auth && config.gateway.auth.token) || '';
+        
+        // Resolve ${ENV_VAR} references in token
+        token = resolveEnvVar(token);
+        
         return { 
           chatUrl: 'http://127.0.0.1:' + port + '/v1/chat/completions',
           toolsUrl: 'http://127.0.0.1:' + port + '/tools/invoke',


### PR DESCRIPTION
## Problem

The WebSocket client (`ws-client.js`) reads the gateway config (`openclaw.json` / `clawdbot.json`) directly with `JSON.parse`, but it does not resolve `${ENV_VAR}` references like OpenClaw does internally.

When `gateway.auth.token` is configured as `${GATEWAY_AUTH_TOKEN}` in the config file, the client sends the literal string `${GATEWAY_AUTH_TOKEN}` as the Bearer token → **401 Unauthorized**.

## Solution

1. **`ws-client.js`**: Add `resolveEnvVar()` helper that matches `${VAR}` patterns and replaces with `process.env[VAR]`
2. **`connect.sh`**: Source `.env` files before launching the node process so environment variables are available

## Changes

### `scripts/ws-client.js`
```javascript
function resolveEnvVar(value) {
  if (!value || typeof value !== 'string') return value;
  var match = value.match(/^\$\{(.+)\}$/);
  if (match) {
    var envName = match[1];
    return process.env[envName] || value;
  }
  return value;
}
```

Applied when loading the gateway token from config.

### `scripts/connect.sh`
```bash
# Source .env so the WS client can resolve ${VAR} references in gateway config
for envfile in "$HOME/.openclaw/.env" "$HOME/.clawdbot/.env"; do
    [ -f "$envfile" ] && set -a && . "$envfile" && set +a
done
```

## Testing

1. Configure gateway token as `${GATEWAY_AUTH_TOKEN}` in openclaw.json
2. Add `GATEWAY_AUTH_TOKEN=your_token` to `~/.openclaw/.env`
3. Start connection: `./scripts/connect.sh start`
4. Verify authentication succeeds (no 401 errors in logs)