### PR TITLE
feat: local development support

### DIFF
--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -1,0 +1,80 @@
+# Local Development Setup
+
+Test ClawdTalk client against a local backend without needing production credentials.
+
+## Prerequisites
+
+1. **Backend running locally** with ngrok tunnel:
+   ```bash
+   cd ~/clawd/projects/clawd-talk-backend/server
+   npm run dev
+   # In another terminal:
+   ngrok http 3000
+   ```
+
+2. **Test user created** in local database with hashed API key:
+   ```sql
+   -- API key: cc_test_localdevkey123
+   -- Hash: a7a9983a8b11c580c1687bb580a3eeee87a81dd390691d5be776939fd09dfd67
+   INSERT INTO users (email, phone, pin_hash, api_key_hash, role)
+   VALUES ('test@local.dev', '+15551234567', 'test', 
+           'a7a9983a8b11c580c1687bb580a3eeee87a81dd390691d5be776939fd09dfd67', 
+           'admin');
+   ```
+
+## Quick Start
+
+```bash
+# 1. Copy local config template
+cp skill-config.local.example.json skill-config.json
+
+# 2. Update your ngrok URL in skill-config.json
+#    Replace YOUR-NGROK-URL with your actual ngrok subdomain
+
+# 3. Install deps
+npm install
+
+# 4. Start the client
+./scripts/connect.sh start
+
+# Or with server override (no config edit needed):
+./scripts/connect.sh start --server https://your-ngrok-url.ngrok-free.dev
+```
+
+## Test Credentials
+
+| Field | Value |
+|-------|-------|
+| API Key | `cc_test_localdevkey123` |
+| API Key Hash | `a7a9983a8b11c580c1687bb580a3eeee87a81dd390691d5be776939fd09dfd67` |
+| Test Phone | `+15551234567` |
+
+## What This Tests
+
+1. **WebSocket connection** - Client connects to local backend
+2. **Authentication** - API key validation against hashed credentials
+3. **Voice call routing** - STT → Gateway → TTS pipeline
+4. **Tool execution** - Agent tool calls via /tools/invoke
+5. **Session routing** - Calls routed to main Clawdbot session
+
+## Troubleshooting
+
+### Connection refused
+- Check backend is running: `curl http://localhost:3000/health`
+- Check ngrok is active: `curl https://your-url.ngrok-free.dev/health`
+
+### Auth failed
+- Verify API key hash in database matches expected value
+- Check `hashApiKey()` function uses SHA-256
+
+### No gateway token
+- Ensure your local Clawdbot/OpenClaw gateway is running
+- Check `~/.clawdbot/clawdbot.json` or `~/.openclaw/openclaw.json` exists with auth token
+
+## Debug Mode
+
+```bash
+DEBUG=1 node scripts/ws-client.js --server https://your-ngrok-url.ngrok-free.dev
+```
+
+Logs all incoming WebSocket messages for debugging.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,25 @@ The gateway auth token in `openclaw.json`/`clawdbot.json` also supports this:
 
 **SMS:** Messages route through the ClawdTalk API. Inbound messages can trigger your bot via webhooks.
 
+## Local Development
+
+Test against a local backend without production credentials:
+
+```bash
+# 1. Copy the local dev config
+cp skill-config.local.example.json skill-config.json
+
+# 2. Update your ngrok URL in skill-config.json
+
+# 3. Start the client
+./scripts/connect.sh start
+
+# Or use --server flag (no config edit needed):
+./scripts/connect.sh start --server https://your-ngrok-url.ngrok-free.dev
+```
+
+See [LOCAL_DEV.md](LOCAL_DEV.md) for full setup instructions including test credentials.
+
 ## Troubleshooting
 
 | Issue | Fix |

--- a/skill-config.local.example.json
+++ b/skill-config.local.example.json
@@ -1,0 +1,7 @@
+{
+  "api_key": "cc_test_localdevkey123",
+  "server": "https://YOUR-NGROK-URL.ngrok-free.dev",
+  "owner_name": "Oliver",
+  "agent_name": "Olitron",
+  "greeting": "Hey, what's up?"
+}


### PR DESCRIPTION
## Summary
Add local development support for testing the WebSocket client against a local backend.

## Changes
- `LOCAL_DEV.md` - Setup instructions for local backend testing
- `skill-config.local.example.json` - Template config with test credentials
- Updated README with local dev section

## Test Credentials
- **API Key:** `cc_test_localdevkey123`
- **Hash:** `a7a9983a8b11c580c1687bb580a3eeee87a81dd390691d5be776939fd09dfd67`

## Usage
```bash
cp skill-config.local.example.json skill-config.json
# Edit ngrok URL
./scripts/connect.sh start
```

Or:
```bash
./scripts/connect.sh start --server https://your-ngrok-url.ngrok-free.dev
```