### PR TITLE
fix: remove docs link and update Discord invite in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 📖 Documentation
-    url: https://clawdtalk.com/docs
-    about: Check the docs before opening an issue
   - name: 💬 OpenClaw Community
-    url: https://discord.com/invite/clawd
+    url: https://discord.gg/StGHNHNc
     about: Chat with the community on Discord


### PR DESCRIPTION
- Removed docs link (we don't have docs yet)
- Updated Discord invite to https://discord.gg/StGHNHNc