### PR TITLE
fix: add gateway tools check for sessions_send

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ The gateway auth token in `openclaw.json`/`clawdbot.json` also supports this:
 }
 ```
 
+### Gateway Tools (Required)
+
+The voice assistant uses `sessions_send` to proxy questions to your Clawdbot. You must allow it on the gateway's `/tools/invoke` endpoint:
+
+```json
+{
+  "gateway": {
+    "tools": {
+      "allow": ["sessions_send"]
+    }
+  }
+}
+```
+
+Without this, the voice assistant will handle calls on its own but won't be able to forward questions to your bot (you'll see `sessions_send failed: 404` in the logs).
+
+Run `./scripts/connect.sh status` to check if this is configured correctly.
+
 ## How It Works
 
 **Voice:** Phone calls connect via Telnyx to the ClawdTalk server. The WebSocket client (`ws-client.js`) routes transcribed speech to your gateway's `/v1/chat/completions` endpoint. Your bot processes it like any other message with the same tools and context. The response is converted to speech and played back.
@@ -147,6 +165,7 @@ The gateway auth token in `openclaw.json`/`clawdbot.json` also supports this:
 |-------|-----|
 | Auth failed | Regenerate API key at clawdtalk.com |
 | Empty responses | Run `./setup.sh`, then `clawdbot gateway restart` |
+| `sessions_send failed: 404` | Add `sessions_send` to `gateway.tools.allow` in your OpenClaw config (see Gateway Tools above) |
 | Connection drops | Check `tail -f .connect.log` for errors |
 | Debug mode | `DEBUG=1 ./scripts/connect.sh restart` |
 

--- a/scripts/connect.sh
+++ b/scripts/connect.sh
@@ -62,6 +62,38 @@ check_config() {
     fi
 }
 
+check_gateway_tools() {
+    # Check if sessions_send is allowed on the gateway /tools/invoke endpoint
+    # Without this, the voice assistant can't proxy questions to the Clawdbot
+    local config_paths=(
+        "$HOME/.openclaw/openclaw.json"
+        "$HOME/.clawdbot/clawdbot.json"
+    )
+    
+    for cfg in "${config_paths[@]}"; do
+        if [ -f "$cfg" ]; then
+            local tools_allow=$(jq -r '.gateway.tools.allow // [] | join(",")' "$cfg" 2>/dev/null)
+            if [ -z "$tools_allow" ] || ! echo "$tools_allow" | grep -q "sessions_send"; then
+                echo -e "${YELLOW}⚠️  Gateway missing 'sessions_send' in tools allowlist${NC}"
+                echo ""
+                echo "   The voice assistant needs sessions_send to proxy questions to your Clawdbot."
+                echo "   Add it to your config ($cfg):"
+                echo ""
+                echo '   "gateway": { "tools": { "allow": ["sessions_send"] } }'
+                echo ""
+                echo "   Or ask your Clawdbot to run:"
+                echo "   openclaw config set gateway.tools.allow '[\"sessions_send\"]'"
+                echo ""
+                return 1
+            fi
+            return 0
+        fi
+    done
+    
+    echo -e "${YELLOW}⚠️  No OpenClaw/Clawdbot config found. Gateway tools check skipped.${NC}"
+    return 0
+}
+
 check_dependencies() {
     for tool in node jq; do
         if ! command -v "$tool" &> /dev/null; then
@@ -201,6 +233,10 @@ show_status() {
         fi
     fi
     
+    # Check gateway tools
+    echo ""
+    check_gateway_tools 2>/dev/null && echo -e "Gateway tools: ${GREEN}sessions_send allowed${NC}" || true
+    
     echo ""
     echo "Configuration:"
     echo "============="
@@ -251,6 +287,7 @@ case "${CMD:-}" in
         print_status
         check_config
         check_dependencies
+        check_gateway_tools || true
         start_connection
         ;;
     stop)
@@ -261,6 +298,7 @@ case "${CMD:-}" in
         print_status
         check_config
         check_dependencies
+        check_gateway_tools || true
         restart_connection
         ;;
     status)


### PR DESCRIPTION
## Problem

The voice assistant proxies questions to the Clawdbot via `sessions_send` on the gateway's `/tools/invoke` endpoint. If `sessions_send` isn't in `gateway.tools.allow`, calls silently fail:

```
ERROR: sessions_send failed: 404 {"ok":false,"error":{"type":"not_found","message":"Tool not available: sessions_send"}}
```

The user sees the voice assistant handle everything itself (or fail), with no indication that the proxy path is broken.

## Changes

- **connect.sh**: Added `check_gateway_tools()` that checks `gateway.tools.allow` in `~/.openclaw/openclaw.json` on start/restart/status. Warns with fix instructions if `sessions_send` is missing.
- **README**: Added "Gateway Tools (Required)" section documenting the config requirement.
- **README**: Added `sessions_send failed: 404` to troubleshooting table.

## Fix for users

Add to OpenClaw config:
```json
{"gateway": {"tools": {"allow": ["sessions_send"]}}}
```

Then restart gateway and WS connection.