### PR TITLE
chore: updating scripts to prevent security warnings on clawhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Start the connection, then call your ClawdTalk number:
 
 Keep it running via crontab:
 
+> **Note:** This keeps a persistent WebSocket connection to clawdtalk.com. Voice transcripts are transmitted in real-time when calls are active.
+
 ```bash
 # Add to crontab (crontab -e):
 @reboot cd ~/clawd/skills/clawdtalk-client && ./scripts/connect.sh start

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,12 +2,30 @@
 name: clawdtalk-client
 version: 2.0.0
 description: ClawdTalk — Voice calls, SMS, and AI Missions for Clawdbot
-metadata: {"clawdbot":{"emoji":"📞","requires":{"bins":["bash","node","jq","python3"]}}}
+metadata: {"clawdbot":{"emoji":"📞","primaryEnv":"CLAWDTALK_API_KEY","homepage":"https://github.com/team-telnyx/clawdtalk-client","requires":{"env":["CLAWDTALK_API_KEY"],"bins":["bash","node","jq","python3"],"config":["skill-config.json","~/.openclaw/openclaw.json","~/.clawdbot/clawdbot.json"]}}}
 ---
 
 # ClawdTalk
 
 Voice calling, SMS messaging, and AI Missions for Clawdbot. Call your bot by phone, send texts, or run autonomous multi-step outreach campaigns — powered by ClawdTalk.
+
+> **Trust:** By using this skill, voice transcripts, SMS messages, and mission data are sent to clawdtalk.com (operated by Telnyx). Only install if you trust this service with your conversation data.
+
+## External Endpoints
+
+| Endpoint | Used by | Data sent |
+|----------|---------|-----------|
+| `https://clawdtalk.com` (WebSocket) | `ws-client.js` | Voice transcripts, tool results, conversation state |
+| `https://clawdtalk.com/v1/*` | `telnyx_api.py` | Mission state, events, scheduled calls/SMS, assistant configs |
+| `http://127.0.0.1:<port>` | `ws-client.js` | Transcribed speech (local gateway only) |
+| `https://raw.githubusercontent.com/team-telnyx/clawdtalk-client/...` | `update.sh` | None (download only) |
+
+## Security & Privacy
+
+- Voice transcripts and SMS content are transmitted to clawdtalk.com.
+- Mission state and events are stored server-side for tracking and insights.
+- `setup.sh` reads gateway config to extract connection details; with confirmation it adds a voice agent and `sessions_send` to `gateway.tools.allow`.
+- API key is stored in `skill-config.json` — use env var `CLAWDTALK_API_KEY` or a `${CLAWDTALK_API_KEY}` reference to avoid plaintext storage.
 
 ---
 
@@ -139,6 +157,7 @@ The script always works with local IDs. You don't need to worry about Telnyx IDs
 2. **Add your phone** in Settings
 3. **Get API key** from Dashboard
 4. **Run setup**: `./setup.sh`
+   > `setup.sh` reads your gateway config to extract connection details, adds a voice agent to `agents.list`, and (with confirmation) adds `sessions_send` to `gateway.tools.allow`. Gateway config is at `~/.openclaw/openclaw.json` or `~/.clawdbot/clawdbot.json`.
 5. **Start connection**: `./scripts/connect.sh start`
 
 ## Voice Calls

--- a/scripts/approval.sh
+++ b/scripts/approval.sh
@@ -11,6 +11,10 @@
 #   ./approval.sh request "Delete 50 files" --biometric --timeout 120
 #   ./approval.sh status <request_id>
 #
+# Env vars: none
+# Endpoints: https://clawdtalk.com
+# Reads: skill-config.json
+# Writes: none
 
 set -e
 

--- a/scripts/call.sh
+++ b/scripts/call.sh
@@ -11,6 +11,10 @@
 #   ./scripts/call.sh status <call_id>                       # Check call status
 #   ./scripts/call.sh end <call_id>                          # End an active call
 #
+# Env vars: none
+# Endpoints: https://clawdtalk.com
+# Reads: skill-config.json
+# Writes: none
 
 set -euo pipefail
 

--- a/scripts/connect.sh
+++ b/scripts/connect.sh
@@ -8,6 +8,10 @@
 #
 # Usage: ./connect.sh {start|stop|status|restart} [--server <url>]
 #
+# Env vars: via .env
+# Endpoints: none (launches ws-client.js)
+# Reads: skill-config.json, .env
+# Writes: .connect.pid, .connect.log
 
 set -e
 

--- a/scripts/sms.sh
+++ b/scripts/sms.sh
@@ -8,6 +8,10 @@
 #   sms.sh list [--limit 20] [--contact +1234567890]
 #   sms.sh conversations
 #
+# Env vars: none
+# Endpoints: https://clawdtalk.com
+# Reads: skill-config.json
+# Writes: none
 
 set -euo pipefail
 

--- a/scripts/telnyx_api.py
+++ b/scripts/telnyx_api.py
@@ -3,6 +3,11 @@
 ClawdTalk AI Missions API client using only Python standard library.
 Proxies all requests through ClawdTalk instead of calling Telnyx directly.
 Usage: python telnyx_api.py <command> [args...]
+
+Env vars: CLAWDTALK_API_KEY, CLAWDTALK_API_URL
+Endpoints: https://clawdtalk.com/v1
+Reads: skill-config.json
+Writes: .missions_state.json
 """
 
 import json

--- a/scripts/ws-client.js
+++ b/scripts/ws-client.js
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /**
  * ClawdTalk WebSocket Client v1.3.0
- * 
+ *
  * Connects to ClawdTalk server and routes voice calls to your Clawdbot gateway.
  * Phone → STT → Gateway Agent → TTS → Phone
- * 
+ *
  * v1.3.0: Instant approval via WebSocket (no more polling delay)
+ *
+ * Env vars: OPENCLAW_GATEWAY_URL, CLAWDBOT_GATEWAY_URL, OPENCLAW_GATEWAY_TOKEN, CLAWDBOT_GATEWAY_TOKEN
+ * Endpoints: https://clawdtalk.com (WebSocket), http://127.0.0.1:<port> (local gateway)
+ * Reads: skill-config.json
+ * Writes: none
  */
 
 const WebSocket = require('ws');

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,10 @@
 #
 # Usage: ./setup.sh
 #
+# Env vars: none directly
+# Endpoints: none
+# Reads: ~/.openclaw/openclaw.json, ~/.clawdbot/clawdbot.json, USER.md, IDENTITY.md
+# Writes: skill-config.json, gateway config
 
 set -e
 
@@ -310,11 +314,7 @@ if [ -n "$GATEWAY_CONFIG" ] && [ -f "$GATEWAY_CONFIG" ]; then
                 mv "$tmp_config" "$GATEWAY_CONFIG"
                 echo "   ✓ Added sessions_send to gateway.tools.allow"
                 sessions_send_allowed=true
-                # Restart gateway
-                if command -v "$CLI_NAME" &> /dev/null; then
-                    echo "   ↻ Restarting gateway..."
-                    $CLI_NAME gateway restart 2>/dev/null && echo "   ✓ Gateway restarted" || echo "   ⚠️  Run '$CLI_NAME gateway restart' manually"
-                fi
+                echo "   ⚠️  Run '$CLI_NAME gateway restart' to apply changes"
             else
                 rm -f "$tmp_config"
                 echo "   ⚠️  Could not auto-configure — add it manually (see below)"

--- a/status.sh
+++ b/status.sh
@@ -6,6 +6,10 @@
 #
 # Usage: ./status.sh
 #
+# Env vars: none
+# Endpoints: none
+# Reads: skill-config.json, .connect.log, .connect.pid
+# Writes: none
 
 set -e
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,6 +7,10 @@
 #
 # Usage: ./uninstall.sh
 #
+# Env vars: none
+# Endpoints: none
+# Reads: skill-config.json, gateway config
+# Writes: gateway config
 
 set -e
 

--- a/update.sh
+++ b/update.sh
@@ -3,6 +3,10 @@
 # ClawdTalk Client Update Script
 # Downloads and installs the latest version from GitHub
 #
+# Env vars: none
+# Endpoints: https://raw.githubusercontent.com, https://api.github.com
+# Reads: package.json
+# Writes: skill files (overwrites on update)
 
 set -e
 


### PR DESCRIPTION
  Summary

  - Expand `SKILL.md` frontmatter metadata with `primaryEnv`, `requires.env`, `requires.config`, and `homepage` to satisfy ClawHub credential and capability declarations
  - Add External Endpoints table, Security & Privacy section, and trust statement to `SKILL.md` body for data-flow transparency
  - Add setup disclosure note in `SKILL.md` Quick Start explaining what setup.sh modifies in gateway config
  - Add persistence disclosure in `README.md` before the `@reboot` cron example
  - Remove the last remaining auto-restart in setup.sh (`sessions_send` section), replacing it with a manual restart warning — consistent with the two spots already fixed in the security PR        
  - Add Env vars / Endpoints / Reads / Writes manifest comment headers to all 10 scripts